### PR TITLE
Feature: Add envelope parameter to Griddler::Email object

### DIFF
--- a/lib/griddler/email.rb
+++ b/lib/griddler/email.rb
@@ -3,7 +3,7 @@ require 'htmlentities'
 module Griddler
   class Email
     include ActionView::Helpers::SanitizeHelper
-    attr_reader :to, :from, :cc, :bcc, :subject, :raw_body, :raw_text, :raw_html, :headers, :raw_headers, :attachments, :content_ids
+    attr_reader :to, :from, :cc, :bcc, :subject, :raw_body, :raw_text, :raw_html, :headers, :raw_headers, :attachments, :content_ids, :envelope
 
     def initialize(params)
       @params = params
@@ -24,6 +24,7 @@ module Griddler
       @raw_headers = params[:headers]
 
       @attachments = params[:attachments]
+      @envelope = params[:envelope]
     end
 
     private

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -730,3 +730,17 @@ describe Griddler::Email, 'with custom configuration' do
     end
   end
 end
+
+describe Griddler::Email, 'with envelope set' do
+  context 'with envelope from payload' do
+    it 'passes envelope to the object' do
+      recipients = ['caleb@example.com', '<joel@example.com>']
+      envelope = "{\"to\":[\"caleb@example.com",\"joel@example.com\"],\"from\":\"ralph@example.com\"}"
+      params = { to: recipients, from: 'ralph@example.com', text: 'hi guys', envelope: envelope }
+
+      email = Griddler::Email.new(params)
+
+      expect(email.envelope).to eq envelope
+    end
+  end
+end


### PR DESCRIPTION
Passing envelope alongside other parameters for easy of parsing of email addresses.