### PR TITLE
✨ feat: add `charsets` attribute to `Email` class

### DIFF
--- a/lib/griddler/email.rb
+++ b/lib/griddler/email.rb
@@ -3,7 +3,7 @@ require 'htmlentities'
 module Griddler
   class Email
     include ActionView::Helpers::SanitizeHelper
-    attr_reader :to, :from, :cc, :bcc, :subject, :raw_body, :raw_text, :raw_html, :headers, :raw_headers, :attachments, :content_ids, :envelope
+    attr_reader :to, :from, :cc, :bcc, :subject, :raw_body, :raw_text, :raw_html, :headers, :raw_headers, :attachments, :content_ids, :envelope, :charsets
 
     def initialize(params)
       @params = params
@@ -25,6 +25,8 @@ module Griddler
 
       @attachments = params[:attachments]
       @envelope = params[:envelope]
+
+      @charsets = params[:charsets]
     end
 
     private

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -735,7 +735,7 @@ describe Griddler::Email, 'with envelope set' do
   context 'with envelope from payload' do
     it 'passes envelope to the object' do
       recipients = ['caleb@example.com', '<joel@example.com>']
-      envelope = "{\"to\":[\"caleb@example.com",\"joel@example.com\"],\"from\":\"ralph@example.com\"}"
+      envelope = "{\"to\":[\"caleb@example.com\",\"joel@example.com\"],\"from\":\"ralph@example.com\"}"
       params = { to: recipients, from: 'ralph@example.com', text: 'hi guys', envelope: envelope }
 
       email = Griddler::Email.new(params)

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -744,3 +744,17 @@ describe Griddler::Email, 'with envelope set' do
     end
   end
 end
+
+describe Griddler::Email, 'with charsets set' do
+  context 'with charsets from payload' do
+    it 'passes charsets to the object' do
+      recipients = ['caleb@example.com', '<joel@example.com>']
+      charsets = { to: 'UTF-8', cc: 'UTF-8', filename: 'UTF-8', subject: 'UTF-8', from: 'UTF-8', text: 'UTF-8' }.to_json
+      params = { to: recipients, from: 'ralph@example.com', text: 'hi guys', charsets: charsets}
+
+      email = Griddler::Email.new(params)
+
+      expect(email.charsets).to eq charsets
+    end
+  end
+end


### PR DESCRIPTION
Add `charsets` attribute to `Griddler::Email` class in order to enable proper handling of non UTF-8 content.