### PR TITLE
ActionController::InvalidAuthenticityToken

### DIFF
--- a/app/controllers/griddler/emails_controller.rb
+++ b/app/controllers/griddler/emails_controller.rb
@@ -1,4 +1,6 @@
 class Griddler::EmailsController < ActionController::Base
+  skip_before_action :verify_authenticity_token, raise: false
+
   def create
     normalized_params.each do |p|
       process_email Griddler::Email.new(p)


### PR DESCRIPTION
For rails with version greater than 5.2 it is necessary to skip token validation in the controller.
