### PR TITLE
ActionController::BadRequest - invalid encoding parameters

### DIFF
--- a/app/controllers/griddler/emails_controller.rb
+++ b/app/controllers/griddler/emails_controller.rb
@@ -1,5 +1,6 @@
 class Griddler::EmailsController < ActionController::Base
   skip_before_action :verify_authenticity_token, raise: false
+  skip_parameter_encoding :create
 
   def create
     normalized_params.each do |p|


### PR DESCRIPTION
After Rails 6.1, by default it is necessary to explicitly state which encodes will be accepted. Since we can receive emails from different encodes, we chose to skip the verification.