### PR TITLE
🐛 stop raising errors when missing the sender email

### DIFF
--- a/lib/griddler/email_parser.rb
+++ b/lib/griddler/email_parser.rb
@@ -60,7 +60,9 @@ module Griddler::EmailParser
   end
 
   def self.extract_email_address(full_address)
-    full_address.split('<').last.delete('>').strip
+    return if full_address.blank?
+
+    full_address.split('<').last.delete('>').strip if full_address.present?
   end
 
   def self.extract_name(full_address)

--- a/lib/griddler/email_parser.rb
+++ b/lib/griddler/email_parser.rb
@@ -60,8 +60,6 @@ module Griddler::EmailParser
   end
 
   def self.extract_email_address(full_address)
-    return if full_address.blank?
-
     full_address.split('<').last.delete('>').strip if full_address.present?
   end
 

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -582,6 +582,25 @@ describe Griddler::Email, 'extracting email addresses' do
 
   end
 
+  it 'handles empty e-mail address' do
+    email = Griddler::Email.new(
+      text: 'hi',
+      from: '',
+      to: ['']
+    )
+
+    expected = {
+      token: nil,
+      host: nil,
+      email: nil,
+      full: '',
+      name: nil
+    }
+
+    expect(email.to).to eq [expected]
+    expect(email.from).to eq expected
+  end
+
   it 'handles empty names' do
     email = Griddler::Email.new(
       text: 'hi',
@@ -591,7 +610,7 @@ describe Griddler::Email, 'extracting email addresses' do
     expected = {
       token: nil,
       host: nil,
-      email: '',
+      email: nil,
       full: ' ',
       name: nil
     }


### PR DESCRIPTION
Before attempting to extract the components of an email address, ensure that the email address is properly validated to avoid raising exceptions.