### PR TITLE
🚑️ safely handle name extraction on nil valued emails

### DIFF
--- a/lib/griddler/email_parser.rb
+++ b/lib/griddler/email_parser.rb
@@ -64,6 +64,8 @@ module Griddler::EmailParser
   end
 
   def self.extract_name(full_address)
+    return if full_address.blank?
+
     full_address = full_address.strip
     name = full_address.split('<').first&.strip
     if name.present? && name != full_address

--- a/lib/griddler/version.rb
+++ b/lib/griddler/version.rb
@@ -1,3 +1,3 @@
 module Griddler
-  VERSION = "1.2.1"
+  VERSION = "1.2.2"
 end

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -601,6 +601,25 @@ describe Griddler::Email, 'extracting email addresses' do
     expect(email.from).to eq expected
   end
 
+  it 'handles null valued e-mail address' do
+    email = Griddler::Email.new(
+      text: 'hi',
+      from: nil,
+      to: []
+    )
+
+    expected = {
+      token: nil,
+      host: nil,
+      email: nil,
+      full: nil,
+      name: nil
+    }
+
+    expect(email.to).to eq []
+    expect(email.from).to eq expected
+  end
+
   it 'handles empty names' do
     email = Griddler::Email.new(
       text: 'hi',


### PR DESCRIPTION
Implement a defensive strategy to extract the sender’s name from emails that are null-valued.